### PR TITLE
Fallback to the US page for "What Is PayPal"

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -808,6 +808,11 @@ class Mage_Paypal_Model_Config
             if ($shouldEmulate) {
                 $locale->revert();
             }
+            // Show the US page when there is no "What Is PayPal" popup window for $countryCode
+            $countryCodeOLCWhatIsPayPal = array("GR");
+            if (in_array($countryCode, $countryCodeOLCWhatIsPayPal)) {
+                $countryCode = 'US';
+            }
         }
         return sprintf('https://www.paypal.com/%s/cgi-bin/webscr?cmd=xpt/Marketing/popup/OLCWhatIsPayPal-outside',
             strtolower($countryCode)


### PR DESCRIPTION
Show the US page when there is no "What Is PayPal" popup window for `$countryCode`. I guess there are more countries like **Greece** that don't have a "What Is PayPal" popup window.